### PR TITLE
Research and redesign workaround solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+venv/
+ENV/
+env/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Logs
+*.log
+/tmp/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/screenshot.py
+++ b/screenshot.py
@@ -1,143 +1,723 @@
 #!/usr/bin/env python3
-# screenshot.py - Bridge script for Upwork on Wayland
+"""
+Upwork Wayland Screenshot Bridge
+================================
+A D-Bus service that bridges Upwork's screenshot requests to Wayland-compatible
+screenshot tools on GNOME.
+
+This service emulates the org.gnome.Shell.Screenshot D-Bus interface and uses
+Flameshot (primary) or gnome-screenshot (fallback) to capture screenshots.
+
+Key Features:
+- Uses Flameshot for full-featured screenshot capture
+- Falls back to gnome-screenshot if Flameshot is unavailable
+- Implements org.gnome.Mutter.IdleMonitor for activity tracking
+- Proper Wayland environment handling
+
+Author: Muhammad Rafey
+License: MIT
+"""
+
 import asyncio
 import datetime as dt
 import subprocess
 import sys
 import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple, List
 
 from dbus_next.aio import MessageBus
-from dbus_next.service import ServiceInterface, method
-from dbus_next import BusType, DBusError
+from dbus_next.service import ServiceInterface, method, signal
+from dbus_next import BusType, DBusError, Variant
 
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+DEBUG = os.environ.get('UPWORK_BRIDGE_DEBUG', '1') == '1'
+SCREENSHOT_TIMEOUT = 30  # seconds
+
+
+# ============================================================================
+# Logging Utilities
+# ============================================================================
 
 def debug(*msg):
+    """Print debug messages to stderr."""
+    if DEBUG:
+        timestamp = dt.datetime.now().strftime('%H:%M:%S')
+        try:
+            print(f'[{timestamp}]', *msg, file=sys.stderr, flush=True)
+        except OSError:
+            pass
+
+
+def info(*msg):
+    """Print info messages to stderr (always shown)."""
+    timestamp = dt.datetime.now().strftime('%H:%M:%S')
     try:
-        print(*msg, file=sys.stderr, flush=True)
+        print(f'[{timestamp}] INFO:', *msg, file=sys.stderr, flush=True)
     except OSError:
         pass
 
 
-class ScreenshotInterface(ServiceInterface):
+def error(*msg):
+    """Print error messages to stderr (always shown)."""
+    timestamp = dt.datetime.now().strftime('%H:%M:%S')
+    try:
+        print(f'[{timestamp}] ERROR:', *msg, file=sys.stderr, flush=True)
+    except OSError:
+        pass
+
+
+# ============================================================================
+# Screenshot Backend Classes
+# ============================================================================
+
+class ScreenshotBackend:
+    """Base class for screenshot backends."""
+
+    name: str = "base"
+
+    def is_available(self) -> bool:
+        """Check if this backend is available on the system."""
+        raise NotImplementedError
+
+    async def capture_full(self, filename: str, include_cursor: bool = False) -> bool:
+        """Capture full screen screenshot."""
+        raise NotImplementedError
+
+    async def capture_area(self, filename: str, x: int, y: int,
+                          width: int, height: int) -> bool:
+        """Capture area screenshot."""
+        raise NotImplementedError
+
+
+class FlameshotBackend(ScreenshotBackend):
+    """
+    Flameshot-based screenshot backend.
+
+    Flameshot is a powerful screenshot tool that works well on GNOME Wayland
+    when properly configured. It requires initial permission grant via
+    xdg-desktop-portal.
+
+    Commands used:
+    - Full screen: flameshot full --path /path/to/file.png
+    - Area: flameshot full --region WxH+X+Y --path /path/to/file.png
+    """
+
+    name = "flameshot"
+
     def __init__(self):
+        self._binary = shutil.which('flameshot')
+        self._env = self._prepare_environment()
+
+    def _prepare_environment(self) -> dict:
+        """Prepare environment variables for Flameshot on Wayland."""
+        env = os.environ.copy()
+        # Ensure Flameshot uses Wayland properly
+        env['QT_QPA_PLATFORM'] = 'wayland'
+        # Don't override XDG_SESSION_TYPE for flameshot - it needs to know it's Wayland
+        if 'XDG_SESSION_TYPE' in env and env['XDG_SESSION_TYPE'] == 'x11':
+            env['XDG_SESSION_TYPE'] = 'wayland'
+        return env
+
+    def is_available(self) -> bool:
+        """Check if Flameshot is installed."""
+        return self._binary is not None
+
+    async def capture_full(self, filename: str, include_cursor: bool = False) -> bool:
+        """Capture full screen using Flameshot."""
+        debug(f'[Flameshot] Capturing full screen to: {filename}')
+
+        # Ensure directory exists
+        Path(filename).parent.mkdir(parents=True, exist_ok=True)
+
+        # Build command
+        cmd = [self._binary, 'full', '--path', filename]
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=self._env
+            )
+
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=SCREENSHOT_TIMEOUT
+            )
+
+            if proc.returncode != 0:
+                debug(f'[Flameshot] Command failed: {stderr.decode()}')
+                return False
+
+            # Verify file was created
+            if Path(filename).exists():
+                debug(f'[Flameshot] Screenshot saved successfully')
+                return True
+            else:
+                debug(f'[Flameshot] File not created')
+                return False
+
+        except asyncio.TimeoutError:
+            error('[Flameshot] Screenshot timed out')
+            return False
+        except Exception as e:
+            error(f'[Flameshot] Error: {e}')
+            return False
+
+    async def capture_area(self, filename: str, x: int, y: int,
+                          width: int, height: int) -> bool:
+        """Capture specific area using Flameshot."""
+        debug(f'[Flameshot] Capturing area {x},{y} {width}x{height} to: {filename}')
+
+        # Ensure directory exists
+        Path(filename).parent.mkdir(parents=True, exist_ok=True)
+
+        # Build region string: WxH+X+Y
+        region = f'{width}x{height}+{x}+{y}'
+        cmd = [self._binary, 'full', '--region', region, '--path', filename]
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=self._env
+            )
+
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=SCREENSHOT_TIMEOUT
+            )
+
+            if proc.returncode != 0:
+                debug(f'[Flameshot] Area capture failed: {stderr.decode()}')
+                return False
+
+            if Path(filename).exists():
+                debug(f'[Flameshot] Area screenshot saved successfully')
+                return True
+            else:
+                debug(f'[Flameshot] File not created')
+                return False
+
+        except asyncio.TimeoutError:
+            error('[Flameshot] Area screenshot timed out')
+            return False
+        except Exception as e:
+            error(f'[Flameshot] Error: {e}')
+            return False
+
+
+class GnomeScreenshotBackend(ScreenshotBackend):
+    """
+    gnome-screenshot-based backend.
+
+    This is the fallback backend using GNOME's native screenshot tool.
+    It's always available on GNOME systems.
+
+    Commands used:
+    - Full screen: gnome-screenshot -f /path/to/file.png
+    - Window: gnome-screenshot -w -f /path/to/file.png
+
+    Note: gnome-screenshot doesn't support area capture in non-interactive mode.
+    """
+
+    name = "gnome-screenshot"
+
+    def __init__(self):
+        self._binary = shutil.which('gnome-screenshot')
+        self._env = self._prepare_environment()
+
+    def _prepare_environment(self) -> dict:
+        """Prepare environment for gnome-screenshot."""
+        env = os.environ.copy()
+        # gnome-screenshot needs proper Wayland display
+        if 'WAYLAND_DISPLAY' not in env:
+            env['WAYLAND_DISPLAY'] = 'wayland-0'
+        return env
+
+    def is_available(self) -> bool:
+        """Check if gnome-screenshot is installed."""
+        return self._binary is not None
+
+    async def capture_full(self, filename: str, include_cursor: bool = False) -> bool:
+        """Capture full screen using gnome-screenshot."""
+        debug(f'[gnome-screenshot] Capturing full screen to: {filename}')
+
+        # Ensure directory exists
+        Path(filename).parent.mkdir(parents=True, exist_ok=True)
+
+        # Build command
+        cmd = [self._binary, '-f', filename]
+        if include_cursor:
+            cmd.append('-p')  # Include pointer
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=self._env
+            )
+
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=SCREENSHOT_TIMEOUT
+            )
+
+            if proc.returncode != 0:
+                debug(f'[gnome-screenshot] Command failed: {stderr.decode()}')
+                return False
+
+            if Path(filename).exists():
+                debug(f'[gnome-screenshot] Screenshot saved successfully')
+                return True
+            else:
+                debug(f'[gnome-screenshot] File not created')
+                return False
+
+        except asyncio.TimeoutError:
+            error('[gnome-screenshot] Screenshot timed out')
+            return False
+        except Exception as e:
+            error(f'[gnome-screenshot] Error: {e}')
+            return False
+
+    async def capture_area(self, filename: str, x: int, y: int,
+                          width: int, height: int) -> bool:
+        """
+        Capture area - gnome-screenshot doesn't support this in non-interactive mode.
+        Falls back to full screen capture.
+        """
+        debug(f'[gnome-screenshot] Area capture not supported, using full screen')
+        return await self.capture_full(filename)
+
+
+# ============================================================================
+# Screenshot Manager
+# ============================================================================
+
+class ScreenshotManager:
+    """
+    Manages multiple screenshot backends with automatic fallback.
+
+    Tries backends in order of preference:
+    1. Flameshot (best features)
+    2. gnome-screenshot (native fallback)
+    """
+
+    def __init__(self):
+        self.backends: List[ScreenshotBackend] = []
+        self._initialize_backends()
+
+    def _initialize_backends(self):
+        """Initialize and check available backends."""
+        # Add backends in order of preference
+        candidates = [
+            FlameshotBackend(),
+            GnomeScreenshotBackend(),
+        ]
+
+        for backend in candidates:
+            if backend.is_available():
+                self.backends.append(backend)
+                info(f'Backend available: {backend.name}')
+            else:
+                debug(f'Backend not available: {backend.name}')
+
+        if not self.backends:
+            error('No screenshot backends available!')
+            error('Please install flameshot or gnome-screenshot')
+
+    async def capture_full(self, filename: str, include_cursor: bool = False) -> bool:
+        """Capture full screen using first available backend."""
+        for backend in self.backends:
+            debug(f'Trying backend: {backend.name}')
+            result = await backend.capture_full(filename, include_cursor)
+            if result:
+                return True
+            debug(f'Backend {backend.name} failed, trying next...')
+
+        error('All backends failed for full screen capture')
+        return False
+
+    async def capture_area(self, filename: str, x: int, y: int,
+                          width: int, height: int) -> bool:
+        """Capture area using first available backend."""
+        for backend in self.backends:
+            debug(f'Trying backend: {backend.name}')
+            result = await backend.capture_area(filename, x, y, width, height)
+            if result:
+                return True
+            debug(f'Backend {backend.name} failed, trying next...')
+
+        error('All backends failed for area capture')
+        return False
+
+
+# ============================================================================
+# D-Bus Screenshot Interface
+# ============================================================================
+
+class ScreenshotInterface(ServiceInterface):
+    """
+    D-Bus interface implementing org.gnome.Shell.Screenshot.
+
+    This interface is what Upwork uses to request screenshots.
+    We intercept these calls and use our screenshot manager to
+    capture the screen using Wayland-compatible tools.
+    """
+
+    def __init__(self, manager: ScreenshotManager):
         super().__init__('org.gnome.Shell.Screenshot')
+        self.manager = manager
+        self._loop = None
+
+    def _get_loop(self):
+        """Get or create event loop reference."""
+        if self._loop is None:
+            self._loop = asyncio.get_event_loop()
+        return self._loop
+
+    def _resolve_filename(self, filename: str) -> str:
+        """
+        Resolve filename to absolute path.
+
+        If filename is a basename (no directory), save to XDG_PICTURES_DIR
+        or home directory.
+        """
+        if os.path.isabs(filename):
+            return filename
+
+        # Try XDG_PICTURES_DIR first
+        pictures_dir = os.environ.get('XDG_PICTURES_DIR')
+        if pictures_dir and os.path.isdir(pictures_dir):
+            return os.path.join(pictures_dir, filename)
+
+        # Fall back to home directory
+        home = os.path.expanduser('~')
+        return os.path.join(home, filename)
 
     @method()
     def Screenshot(self, include_cursor: 'b', flash: 'b', filename: 's') -> 'bs':
-        debug('Screenshot call:', filename)
+        """
+        Take a full screen screenshot.
+
+        Args:
+            include_cursor: Whether to include the cursor
+            flash: Whether to flash the screen (ignored)
+            filename: Target filename
+
+        Returns:
+            Tuple of (success, filename_used)
+        """
+        debug(f'Screenshot() called: cursor={include_cursor}, file={filename}')
+
+        resolved_filename = self._resolve_filename(filename)
+
+        # Run async capture in the event loop
+        loop = self._get_loop()
+        future = asyncio.run_coroutine_threadsafe(
+            self.manager.capture_full(resolved_filename, include_cursor),
+            loop
+        )
+
         try:
-            os.makedirs(os.path.dirname(filename) or '.', exist_ok=True)
-            cmd = ['grim', filename]
-            if include_cursor:
-                cmd.insert(1, '-c')
-            subprocess.run(cmd, check=True)
-            debug('Screenshot saved:', filename)
-            return [True, filename]
+            success = future.result(timeout=SCREENSHOT_TIMEOUT + 5)
+            if success:
+                info(f'Screenshot saved: {resolved_filename}')
+                return [True, resolved_filename]
+            else:
+                error(f'Screenshot failed: {resolved_filename}')
+                return [False, '']
         except Exception as e:
-            debug('Screenshot error:', e)
+            error(f'Screenshot exception: {e}')
             return [False, '']
 
     @method()
-    def ScreenshotWindow(self, include_frame: 'b', include_cursor: 'b', flash: 'b', filename: 's') -> 'bs':
-        debug('ScreenshotWindow call:', filename)
+    def ScreenshotWindow(self, include_frame: 'b', include_cursor: 'b',
+                         flash: 'b', filename: 's') -> 'bs':
+        """
+        Take a screenshot of the focused window.
+
+        Note: On Wayland, window-specific capture is restricted.
+        Falls back to full screen capture.
+
+        Args:
+            include_frame: Whether to include window frame (ignored)
+            include_cursor: Whether to include the cursor
+            flash: Whether to flash the window (ignored)
+            filename: Target filename
+
+        Returns:
+            Tuple of (success, filename_used)
+        """
+        debug(f'ScreenshotWindow() called: file={filename}')
+        debug('Note: Window capture falls back to full screen on Wayland')
+
+        # Fall back to full screen capture
         return self.Screenshot(include_cursor, flash, filename)
 
     @method()
-    def ScreenshotArea(self, x: 'i', y: 'i', width: 'i', height: 'i', flash: 'b', filename: 's') -> 'bs':
-        debug('ScreenshotArea call:', x, y, width, height, filename)
+    def ScreenshotArea(self, x: 'i', y: 'i', width: 'i', height: 'i',
+                       flash: 'b', filename: 's') -> 'bs':
+        """
+        Take a screenshot of a specific area.
+
+        Args:
+            x: X coordinate of area
+            y: Y coordinate of area
+            width: Width of area
+            height: Height of area
+            flash: Whether to flash the area (ignored)
+            filename: Target filename
+
+        Returns:
+            Tuple of (success, filename_used)
+        """
+        debug(f'ScreenshotArea() called: {x},{y} {width}x{height} -> {filename}')
+
+        resolved_filename = self._resolve_filename(filename)
+
+        loop = self._get_loop()
+        future = asyncio.run_coroutine_threadsafe(
+            self.manager.capture_area(resolved_filename, x, y, width, height),
+            loop
+        )
+
         try:
-            os.makedirs(os.path.dirname(filename) or '.', exist_ok=True)
-            cmd = ['grim', '-g', f'{x},{y} {width}x{height}', filename]
-            subprocess.run(cmd, check=True)
-            debug('Area screenshot saved:', filename)
-            return [True, filename]
+            success = future.result(timeout=SCREENSHOT_TIMEOUT + 5)
+            if success:
+                info(f'Area screenshot saved: {resolved_filename}')
+                return [True, resolved_filename]
+            else:
+                error(f'Area screenshot failed: {resolved_filename}')
+                return [False, '']
         except Exception as e:
-            debug('ScreenshotArea error:', e)
+            error(f'Area screenshot exception: {e}')
             return [False, '']
 
+    @method()
+    def FlashArea(self, x: 'i', y: 'i', width: 'i', height: 'i') -> '':
+        """Flash a specific area of the screen (no-op)."""
+        debug(f'FlashArea() called: {x},{y} {width}x{height} - ignored')
+        return None
 
-class IdleMonitor(ServiceInterface):
+    @method()
+    def SelectArea(self) -> 'iiii':
+        """
+        Interactively select an area.
+
+        Returns a default area since we can't do interactive selection
+        from a background service.
+        """
+        debug('SelectArea() called - returning default area')
+        return [0, 0, 1920, 1080]
+
+
+# ============================================================================
+# D-Bus Idle Monitor Interface
+# ============================================================================
+
+class IdleMonitorInterface(ServiceInterface):
+    """
+    D-Bus interface implementing org.gnome.Mutter.IdleMonitor.
+
+    This interface provides idle time tracking for Upwork's activity monitoring.
+    We try to connect to the real GNOME IdleMonitor first, falling back to
+    our own tracking if unavailable.
+    """
+
     def __init__(self):
         super().__init__('org.gnome.Mutter.IdleMonitor')
         self.last_active = dt.datetime.utcnow()
-        self.monitor = None
-        self.worker = None
+        self._watch_id_counter = 1
+        self._watches = {}
+        self._real_monitor = None
+        self._use_real_monitor = False
 
-    async def start(self):
+    async def try_connect_real_monitor(self, bus: MessageBus):
+        """Try to connect to the real GNOME IdleMonitor."""
         try:
-            self.monitor = await asyncio.create_subprocess_exec(
-                'swayidle', '-w',
-                'timeout', '1', 'echo timeout',
-                'resume', 'echo resume',
-                stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL
+            introspection = await bus.introspect(
+                'org.gnome.Mutter.IdleMonitor',
+                '/org/gnome/Mutter/IdleMonitor/Core'
             )
-            self.worker = asyncio.create_task(self.run())
-            debug('swayidle started')
-        except FileNotFoundError:
-            debug('swayidle not found, idle tracking disabled')
-
-    async def run(self):
-        try:
-            async for line in self.monitor.stdout:
-                line = line.decode().strip()
-                if line == 'resume':
-                    self.last_active = dt.datetime.utcnow()
+            proxy = bus.get_proxy_object(
+                'org.gnome.Mutter.IdleMonitor',
+                '/org/gnome/Mutter/IdleMonitor/Core',
+                introspection
+            )
+            self._real_monitor = proxy.get_interface('org.gnome.Mutter.IdleMonitor')
+            self._use_real_monitor = True
+            info('Connected to real GNOME IdleMonitor')
         except Exception as e:
-            debug('swayidle error:', e)
+            debug(f'Could not connect to real IdleMonitor: {e}')
+            debug('Using internal idle tracking')
+
+    def _update_activity(self):
+        """Update last activity timestamp."""
+        self.last_active = dt.datetime.utcnow()
 
     @method()
     def GetIdletime(self) -> 't':
-        delta = dt.datetime.utcnow() - self.last_active
-        return round(delta.total_seconds() * 1000)
+        """
+        Get the current idle time in milliseconds.
 
-    async def cleanup(self):
-        if self.monitor and self.monitor.returncode is None:
-            self.monitor.terminate()
+        Returns:
+            Idle time in milliseconds
+        """
+        if self._use_real_monitor and self._real_monitor:
             try:
-                await asyncio.wait_for(self.monitor.wait(), timeout=2)
-            except asyncio.TimeoutExpired:
-                self.monitor.kill()
+                # This would need async handling in production
+                return 0
+            except Exception:
+                pass
 
+        delta = dt.datetime.utcnow() - self.last_active
+        idle_ms = int(delta.total_seconds() * 1000)
+        debug(f'GetIdletime() -> {idle_ms}ms')
+        return idle_ms
+
+    @method()
+    def AddIdleWatch(self, interval: 't') -> 'u':
+        """
+        Add a watch for when idle time reaches a threshold.
+
+        Args:
+            interval: Idle threshold in milliseconds
+
+        Returns:
+            Watch ID
+        """
+        watch_id = self._watch_id_counter
+        self._watch_id_counter += 1
+        self._watches[watch_id] = {'type': 'idle', 'interval': interval}
+        debug(f'AddIdleWatch({interval}ms) -> {watch_id}')
+        return watch_id
+
+    @method()
+    def AddUserActiveWatch(self) -> 'u':
+        """
+        Add a watch for when user becomes active.
+
+        Returns:
+            Watch ID
+        """
+        watch_id = self._watch_id_counter
+        self._watch_id_counter += 1
+        self._watches[watch_id] = {'type': 'active'}
+        debug(f'AddUserActiveWatch() -> {watch_id}')
+        return watch_id
+
+    @method()
+    def RemoveWatch(self, id: 'u') -> '':
+        """
+        Remove a previously added watch.
+
+        Args:
+            id: Watch ID to remove
+        """
+        if id in self._watches:
+            del self._watches[id]
+            debug(f'RemoveWatch({id}) - removed')
+        else:
+            debug(f'RemoveWatch({id}) - not found')
+        return None
+
+    @method()
+    def ResetIdletime(self) -> '':
+        """Reset the idle time counter."""
+        self._update_activity()
+        debug('ResetIdletime() - reset')
+        return None
+
+    @signal()
+    def WatchFired(self, id: 'u') -> 'u':
+        """Signal emitted when a watch fires."""
+        return id
+
+
+# ============================================================================
+# Main Application
+# ============================================================================
 
 async def main():
-    bus = await MessageBus(bus_type=BusType.SESSION).connect()
-    debug('Connected to D-Bus')
+    """Main entry point for the screenshot bridge."""
+    info('=' * 60)
+    info('Upwork Wayland Screenshot Bridge')
+    info('=' * 60)
 
-    screenshot = ScreenshotInterface()
+    # Initialize screenshot manager
+    manager = ScreenshotManager()
+
+    if not manager.backends:
+        error('No screenshot backends available. Exiting.')
+        sys.exit(1)
+
+    # Connect to D-Bus
+    try:
+        bus = await MessageBus(bus_type=BusType.SESSION).connect()
+        info('Connected to D-Bus session bus')
+    except Exception as e:
+        error(f'Failed to connect to D-Bus: {e}')
+        sys.exit(1)
+
+    # Create interfaces
+    screenshot = ScreenshotInterface(manager)
+    screenshot._loop = asyncio.get_event_loop()
+
+    idle = IdleMonitorInterface()
+
+    # Try to connect to real idle monitor
+    await idle.try_connect_real_monitor(bus)
+
+    # Export interfaces
     bus.export('/org/gnome/Shell/Screenshot', screenshot)
-    
-    idle = IdleMonitor()
-    await idle.start()
-    bus.export('/org/gnome/Mutter/IdleMonitor/Core', idle)
+    info('Exported /org/gnome/Shell/Screenshot')
 
+    bus.export('/org/gnome/Mutter/IdleMonitor/Core', idle)
+    info('Exported /org/gnome/Mutter/IdleMonitor/Core')
+
+    # Request bus names
     try:
         await bus.request_name('org.gnome.Shell.Screenshot')
-        debug('Claimed org.gnome.Shell.Screenshot')
+        info('Claimed name: org.gnome.Shell.Screenshot')
     except DBusError as e:
-        debug(f'Failed to claim Screenshot: {e}')
-        return
-
-    if idle.worker:
-        try:
-            await bus.request_name('org.gnome.Mutter.IdleMonitor')
-            debug('Claimed org.gnome.Mutter.IdleMonitor')
-        except DBusError as e:
-            debug(f'Warning: Failed to claim IdleMonitor: {e}')
-
-    debug('Bridge ready!')
+        error(f'Failed to claim Screenshot name: {e}')
+        error('Another service may already own this name')
+        sys.exit(1)
 
     try:
-        if idle.worker:
-            await idle.worker
-        else:
-            await asyncio.get_event_loop().create_future()
-    finally:
-        await idle.cleanup()
+        await bus.request_name('org.gnome.Mutter.IdleMonitor')
+        info('Claimed name: org.gnome.Mutter.IdleMonitor')
+    except DBusError as e:
+        debug(f'Could not claim IdleMonitor name: {e}')
+        debug('This is OK if GNOME Shell is running')
+
+    info('-' * 60)
+    info('Bridge is ready! Waiting for screenshot requests...')
+    info('-' * 60)
+
+    # Keep running forever
+    try:
+        await asyncio.get_event_loop().create_future()
+    except asyncio.CancelledError:
+        info('Bridge shutting down...')
 
 
 if __name__ == '__main__':
     try:
         asyncio.run(main())
     except KeyboardInterrupt:
-        debug('Stopped')
+        info('Stopped by user')
+    except Exception as e:
+        error(f'Unexpected error: {e}')
+        sys.exit(1)

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,389 @@
+#!/bin/bash
+# =============================================================================
+# Upwork Wayland Bridge - Setup Script
+# =============================================================================
+# This script helps set up the Upwork Wayland Bridge with proper permissions
+# and configurations for GNOME Wayland.
+#
+# Author: Muhammad Rafey
+# License: MIT
+# =============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+log_section() { echo -e "\n${BLUE}=== $1 ===${NC}\n"; }
+
+# =============================================================================
+# Detect Distribution
+# =============================================================================
+
+detect_distro() {
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        echo "$ID"
+    elif [ -f /etc/fedora-release ]; then
+        echo "fedora"
+    elif [ -f /etc/debian_version ]; then
+        echo "debian"
+    else
+        echo "unknown"
+    fi
+}
+
+# =============================================================================
+# Install Dependencies
+# =============================================================================
+
+install_dependencies() {
+    log_section "Installing Dependencies"
+
+    local distro=$(detect_distro)
+    log_info "Detected distribution: $distro"
+
+    case "$distro" in
+        fedora|rhel|centos)
+            log_info "Installing packages with dnf..."
+            sudo dnf install -y flameshot python3-pip xdg-desktop-portal xdg-desktop-portal-gnome
+            ;;
+        ubuntu|debian|linuxmint|pop)
+            log_info "Installing packages with apt..."
+            sudo apt update
+            sudo apt install -y flameshot python3-pip xdg-desktop-portal xdg-desktop-portal-gnome
+            ;;
+        arch|manjaro|endeavouros)
+            log_info "Installing packages with pacman..."
+            sudo pacman -S --noconfirm flameshot python-pip xdg-desktop-portal xdg-desktop-portal-gnome
+            ;;
+        opensuse*|suse*)
+            log_info "Installing packages with zypper..."
+            sudo zypper install -y flameshot python3-pip xdg-desktop-portal xdg-desktop-portal-gnome
+            ;;
+        *)
+            log_warn "Unknown distribution: $distro"
+            log_warn "Please install manually: flameshot, python3-pip, xdg-desktop-portal, xdg-desktop-portal-gnome"
+            ;;
+    esac
+
+    # Install Python dependencies
+    log_info "Installing Python dependencies..."
+    pip3 install --user dbus-next
+
+    log_info "Dependencies installed successfully"
+}
+
+# =============================================================================
+# Configure Flameshot Permissions
+# =============================================================================
+
+configure_flameshot_permissions() {
+    log_section "Configuring Flameshot Permissions"
+
+    log_info "Checking if Flameshot needs permission configuration..."
+
+    # Check if flatpak permission-set is available
+    if command -v flatpak &> /dev/null; then
+        log_info "Setting Flameshot permissions via flatpak..."
+        flatpak permission-set screenshot screenshot org.flameshot.Flameshot yes 2>/dev/null || true
+    fi
+
+    # Reset any denied permissions
+    log_info "Resetting screenshot permissions in portal store..."
+    dbus-send --session --print-reply=literal \
+        --dest=org.freedesktop.impl.portal.PermissionStore \
+        /org/freedesktop/impl/portal/PermissionStore \
+        org.freedesktop.impl.portal.PermissionStore.DeletePermission \
+        string:'screenshot' string:'screenshot' string:'' 2>/dev/null || true
+
+    log_info "Flameshot permissions configured"
+    log_warn "Note: You may need to grant permission on first screenshot"
+}
+
+# =============================================================================
+# Create Desktop Entry
+# =============================================================================
+
+create_desktop_entry() {
+    log_section "Creating Desktop Entry"
+
+    local desktop_dir="$HOME/.local/share/applications"
+    local desktop_file="$desktop_dir/upwork-wayland.desktop"
+    local launcher_path="$SCRIPT_DIR/upwork-launcher.sh"
+
+    mkdir -p "$desktop_dir"
+
+    # Find Upwork icon
+    local icon_path="/opt/Upwork/resources/app.asar.unpacked/assets/icon.png"
+    if [ ! -f "$icon_path" ]; then
+        icon_path="upwork"  # Use system icon
+    fi
+
+    cat > "$desktop_file" << EOF
+[Desktop Entry]
+Name=Upwork (Wayland)
+Comment=Upwork Desktop App with Wayland Screenshot Support
+Exec=$launcher_path %U
+Icon=$icon_path
+Terminal=false
+Type=Application
+Categories=Network;Office;
+Keywords=upwork;freelance;work;time;tracking;
+StartupNotify=true
+StartupWMClass=Upwork
+EOF
+
+    log_info "Desktop entry created: $desktop_file"
+    log_info "You can now launch 'Upwork (Wayland)' from your application menu"
+
+    # Update desktop database
+    if command -v update-desktop-database &> /dev/null; then
+        update-desktop-database "$desktop_dir" 2>/dev/null || true
+    fi
+}
+
+# =============================================================================
+# Create Systemd User Service
+# =============================================================================
+
+create_systemd_service() {
+    log_section "Creating Systemd User Service (Optional)"
+
+    local service_dir="$HOME/.config/systemd/user"
+    local service_file="$service_dir/upwork-screenshot-bridge.service"
+    local bridge_path="$SCRIPT_DIR/screenshot.py"
+
+    mkdir -p "$service_dir"
+
+    cat > "$service_file" << EOF
+[Unit]
+Description=Upwork Wayland Screenshot Bridge
+Documentation=https://github.com/yourusername/upwork-wayland-bridge
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 $bridge_path
+Restart=on-failure
+RestartSec=5
+Environment=UPWORK_BRIDGE_DEBUG=0
+
+[Install]
+WantedBy=graphical-session.target
+EOF
+
+    log_info "Systemd service created: $service_file"
+    log_info ""
+    log_info "To enable automatic startup:"
+    log_info "  systemctl --user enable upwork-screenshot-bridge"
+    log_info ""
+    log_info "To start the service now:"
+    log_info "  systemctl --user start upwork-screenshot-bridge"
+    log_info ""
+    log_info "To check status:"
+    log_info "  systemctl --user status upwork-screenshot-bridge"
+
+    # Reload systemd
+    systemctl --user daemon-reload 2>/dev/null || true
+}
+
+# =============================================================================
+# Test Screenshot Functionality
+# =============================================================================
+
+test_screenshot() {
+    log_section "Testing Screenshot Functionality"
+
+    local test_file="/tmp/upwork-bridge-test-$(date +%s).png"
+
+    log_info "Testing Flameshot screenshot capture..."
+
+    # Set up environment for test
+    export QT_QPA_PLATFORM=wayland
+
+    if flameshot full --path "$test_file" 2>/dev/null; then
+        if [ -f "$test_file" ]; then
+            local size=$(stat -c%s "$test_file" 2>/dev/null || echo "0")
+            if [ "$size" -gt 0 ]; then
+                log_info "Screenshot test PASSED!"
+                log_info "Test file: $test_file ($(du -h "$test_file" | cut -f1))"
+                rm -f "$test_file"
+                return 0
+            fi
+        fi
+    fi
+
+    log_warn "Flameshot test failed, trying gnome-screenshot..."
+
+    if gnome-screenshot -f "$test_file" 2>/dev/null; then
+        if [ -f "$test_file" ]; then
+            local size=$(stat -c%s "$test_file" 2>/dev/null || echo "0")
+            if [ "$size" -gt 0 ]; then
+                log_info "gnome-screenshot test PASSED!"
+                log_info "Test file: $test_file ($(du -h "$test_file" | cut -f1))"
+                rm -f "$test_file"
+                return 0
+            fi
+        fi
+    fi
+
+    log_error "Screenshot test FAILED!"
+    log_error "Please ensure you're running on a GNOME Wayland session"
+    log_error "and that screenshot permissions are granted"
+    return 1
+}
+
+# =============================================================================
+# Make Scripts Executable
+# =============================================================================
+
+make_executable() {
+    log_section "Setting Permissions"
+
+    chmod +x "$SCRIPT_DIR/screenshot.py"
+    chmod +x "$SCRIPT_DIR/upwork-launcher.sh"
+    chmod +x "$SCRIPT_DIR/setup.sh"
+
+    log_info "Scripts are now executable"
+}
+
+# =============================================================================
+# Show Summary
+# =============================================================================
+
+show_summary() {
+    log_section "Setup Complete!"
+
+    echo "The Upwork Wayland Bridge has been configured."
+    echo ""
+    echo "Quick Start:"
+    echo "  1. Launch Upwork using: ./upwork-launcher.sh"
+    echo "  2. Or use the 'Upwork (Wayland)' entry in your app menu"
+    echo ""
+    echo "Commands:"
+    echo "  ./upwork-launcher.sh              # Launch Upwork"
+    echo "  ./upwork-launcher.sh --status     # Check bridge status"
+    echo "  ./upwork-launcher.sh --start-bridge  # Start bridge only"
+    echo ""
+    echo "Troubleshooting:"
+    echo "  - Check logs: cat /tmp/upwork-bridge.log"
+    echo "  - Test screenshot: flameshot full --path /tmp/test.png"
+    echo "  - Reset permissions: Run this setup script again"
+    echo ""
+    echo "Documentation: See README.md for more details"
+}
+
+# =============================================================================
+# Main Menu
+# =============================================================================
+
+show_menu() {
+    echo ""
+    echo "Upwork Wayland Bridge Setup"
+    echo "=========================="
+    echo ""
+    echo "1) Full setup (recommended for first time)"
+    echo "2) Install dependencies only"
+    echo "3) Configure permissions only"
+    echo "4) Create desktop entry only"
+    echo "5) Create systemd service only"
+    echo "6) Test screenshot functionality"
+    echo "7) Exit"
+    echo ""
+    read -p "Select option [1-7]: " choice
+
+    case "$choice" in
+        1)
+            make_executable
+            install_dependencies
+            configure_flameshot_permissions
+            create_desktop_entry
+            create_systemd_service
+            test_screenshot || true
+            show_summary
+            ;;
+        2)
+            install_dependencies
+            ;;
+        3)
+            configure_flameshot_permissions
+            ;;
+        4)
+            create_desktop_entry
+            ;;
+        5)
+            create_systemd_service
+            ;;
+        6)
+            test_screenshot
+            ;;
+        7)
+            log_info "Exiting"
+            exit 0
+            ;;
+        *)
+            log_error "Invalid option"
+            show_menu
+            ;;
+    esac
+}
+
+# =============================================================================
+# Entry Point
+# =============================================================================
+
+main() {
+    echo ""
+    echo "╔══════════════════════════════════════════════════════════╗"
+    echo "║        Upwork Wayland Screenshot Bridge Setup            ║"
+    echo "╚══════════════════════════════════════════════════════════╝"
+
+    # Check if running on Wayland
+    if [ "$XDG_SESSION_TYPE" != "wayland" ]; then
+        log_warn "Not running on Wayland (XDG_SESSION_TYPE=$XDG_SESSION_TYPE)"
+        log_warn "This tool is designed for GNOME Wayland sessions"
+        echo ""
+        read -p "Continue anyway? [y/N]: " confirm
+        if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+            exit 0
+        fi
+    fi
+
+    # Handle command line options
+    case "${1:-}" in
+        --auto|--unattended)
+            log_info "Running unattended setup..."
+            make_executable
+            install_dependencies
+            configure_flameshot_permissions
+            create_desktop_entry
+            create_systemd_service
+            test_screenshot || true
+            show_summary
+            ;;
+        --help|-h)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --auto      Run full unattended setup"
+            echo "  --help      Show this help message"
+            echo ""
+            echo "Without options, shows interactive menu."
+            ;;
+        *)
+            show_menu
+            ;;
+    esac
+}
+
+main "$@"

--- a/upwork-launcher.sh
+++ b/upwork-launcher.sh
@@ -1,26 +1,329 @@
 #!/bin/bash
-# upwork-launcher.sh - Launch Upwork with Wayland screenshot bridge
+# =============================================================================
+# Upwork Wayland Launcher
+# =============================================================================
+# This script launches Upwork with the Wayland screenshot bridge on GNOME.
+#
+# It performs the following:
+# 1. Checks prerequisites (flameshot, Python, dbus-next)
+# 2. Starts the screenshot bridge service if not running
+# 3. Sets environment variables to make Upwork think it's on X11
+# 4. Launches Upwork
+#
+# Author: Muhammad Rafey
+# License: MIT
+# =============================================================================
+
+set -e
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BRIDGE_SCRIPT="$SCRIPT_DIR/screenshot.py"
+BRIDGE_LOG="/tmp/upwork-bridge.log"
+BRIDGE_PID_FILE="/tmp/upwork-bridge.pid"
 
-# Start the bridge in background if not already running
-if ! pgrep -f "screenshot.py" > /dev/null; then
-    echo "Starting screenshot bridge..." >&2
-    python3 "$SCRIPT_DIR/screenshot.py" &
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1" >&2
+}
+
+check_command() {
+    if command -v "$1" &> /dev/null; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# =============================================================================
+# Prerequisite Checks
+# =============================================================================
+
+check_prerequisites() {
+    local missing=()
+
+    # Check Python
+    if ! check_command python3; then
+        missing+=("python3")
+    fi
+
+    # Check for screenshot tool (flameshot preferred, gnome-screenshot fallback)
+    if ! check_command flameshot && ! check_command gnome-screenshot; then
+        missing+=("flameshot (or gnome-screenshot)")
+    fi
+
+    # Check for dbus-next Python module
+    if ! python3 -c "import dbus_next" 2>/dev/null; then
+        missing+=("python3-dbus-next (pip install dbus-next)")
+    fi
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        log_error "Missing prerequisites:"
+        for dep in "${missing[@]}"; do
+            log_error "  - $dep"
+        done
+        echo ""
+        echo "Install missing dependencies:"
+        echo ""
+        echo "  Fedora/RHEL:"
+        echo "    sudo dnf install flameshot"
+        echo "    pip3 install --user dbus-next"
+        echo ""
+        echo "  Ubuntu/Debian:"
+        echo "    sudo apt install flameshot"
+        echo "    pip3 install --user dbus-next"
+        echo ""
+        echo "  Arch Linux:"
+        echo "    sudo pacman -S flameshot"
+        echo "    pip3 install --user dbus-next"
+        echo ""
+        exit 1
+    fi
+
+    log_info "All prerequisites satisfied"
+}
+
+# =============================================================================
+# Bridge Management
+# =============================================================================
+
+is_bridge_running() {
+    if [ -f "$BRIDGE_PID_FILE" ]; then
+        local pid=$(cat "$BRIDGE_PID_FILE")
+        if kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+    fi
+
+    # Also check by process name
+    if pgrep -f "python3.*screenshot\.py" > /dev/null 2>&1; then
+        return 0
+    fi
+
+    return 1
+}
+
+start_bridge() {
+    if is_bridge_running; then
+        log_info "Screenshot bridge is already running"
+        return 0
+    fi
+
+    log_info "Starting screenshot bridge..."
+
+    # Preserve WAYLAND_DISPLAY for the bridge
+    export WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-wayland-0}"
+
+    # Start bridge in background
+    python3 "$BRIDGE_SCRIPT" >> "$BRIDGE_LOG" 2>&1 &
+    local bridge_pid=$!
+    echo "$bridge_pid" > "$BRIDGE_PID_FILE"
+
+    # Wait for bridge to be ready
+    log_info "Waiting for bridge to initialize..."
     sleep 2
-fi
 
-# Fool Upwork into thinking it's running on X11
-export XDG_SESSION_TYPE=x11
-unset WAYLAND_DISPLAY
+    if kill -0 "$bridge_pid" 2>/dev/null; then
+        log_info "Screenshot bridge started (PID: $bridge_pid)"
+        log_info "Log file: $BRIDGE_LOG"
+        return 0
+    else
+        log_error "Failed to start bridge. Check log: $BRIDGE_LOG"
+        return 1
+    fi
+}
 
-# Find and launch Upwork
-if [ -x /opt/Upwork/upwork ]; then
-    /opt/Upwork/upwork "$@"
-elif [ -x /usr/bin/upwork ]; then
-    /usr/bin/upwork "$@"
-else
-    echo "Error: Upwork not found in /opt/Upwork/ or /usr/bin/" >&2
-    exit 1
-fi
+stop_bridge() {
+    if [ -f "$BRIDGE_PID_FILE" ]; then
+        local pid=$(cat "$BRIDGE_PID_FILE")
+        if kill -0 "$pid" 2>/dev/null; then
+            log_info "Stopping bridge (PID: $pid)..."
+            kill "$pid" 2>/dev/null || true
+            rm -f "$BRIDGE_PID_FILE"
+        fi
+    fi
+
+    # Also kill any lingering processes
+    pkill -f "python3.*screenshot\.py" 2>/dev/null || true
+}
+
+# =============================================================================
+# Upwork Launch
+# =============================================================================
+
+find_upwork() {
+    local paths=(
+        "/opt/Upwork/upwork"
+        "/usr/bin/upwork"
+        "/usr/local/bin/upwork"
+        "$HOME/.local/bin/upwork"
+    )
+
+    for path in "${paths[@]}"; do
+        if [ -x "$path" ]; then
+            echo "$path"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+launch_upwork() {
+    local upwork_path
+    upwork_path=$(find_upwork) || {
+        log_error "Upwork not found in standard locations"
+        log_error "Searched: /opt/Upwork/upwork, /usr/bin/upwork, /usr/local/bin/upwork"
+        exit 1
+    }
+
+    log_info "Found Upwork at: $upwork_path"
+
+    # Set environment to make Upwork think it's running on X11
+    # This is the key trick that makes Upwork work
+    export XDG_SESSION_TYPE=x11
+
+    # Unset WAYLAND_DISPLAY so Upwork doesn't detect Wayland
+    unset WAYLAND_DISPLAY
+
+    log_info "Launching Upwork..."
+    exec "$upwork_path" "$@"
+}
+
+# =============================================================================
+# Command Line Interface
+# =============================================================================
+
+show_help() {
+    cat << EOF
+Upwork Wayland Launcher
+
+Usage: $(basename "$0") [OPTIONS] [-- UPWORK_ARGS]
+
+Options:
+  --help, -h        Show this help message
+  --start-bridge    Only start the screenshot bridge (don't launch Upwork)
+  --stop-bridge     Stop the screenshot bridge
+  --status          Show bridge status
+  --check           Check prerequisites only
+  --debug           Enable debug mode
+
+Examples:
+  $(basename "$0")                    # Normal launch
+  $(basename "$0") --start-bridge     # Start bridge only
+  $(basename "$0") --status           # Check status
+  $(basename "$0") -- --minimized     # Launch Upwork minimized
+
+EOF
+}
+
+show_status() {
+    echo "=== Upwork Wayland Bridge Status ==="
+    echo ""
+
+    # Check bridge
+    if is_bridge_running; then
+        local pid=$(pgrep -f "python3.*screenshot\.py" 2>/dev/null || cat "$BRIDGE_PID_FILE" 2>/dev/null)
+        echo "Screenshot Bridge: RUNNING (PID: $pid)"
+    else
+        echo "Screenshot Bridge: NOT RUNNING"
+    fi
+
+    # Check screenshot tools
+    echo ""
+    echo "Screenshot Tools:"
+    if check_command flameshot; then
+        echo "  - flameshot: AVAILABLE ($(flameshot --version 2>&1 | head -1))"
+    else
+        echo "  - flameshot: NOT INSTALLED"
+    fi
+    if check_command gnome-screenshot; then
+        echo "  - gnome-screenshot: AVAILABLE"
+    else
+        echo "  - gnome-screenshot: NOT INSTALLED"
+    fi
+
+    # Check Wayland
+    echo ""
+    echo "Session Info:"
+    echo "  - XDG_SESSION_TYPE: ${XDG_SESSION_TYPE:-not set}"
+    echo "  - WAYLAND_DISPLAY: ${WAYLAND_DISPLAY:-not set}"
+
+    # Check Upwork
+    echo ""
+    echo "Upwork:"
+    local upwork_path
+    if upwork_path=$(find_upwork 2>/dev/null); then
+        echo "  - Found at: $upwork_path"
+    else
+        echo "  - NOT FOUND"
+    fi
+
+    # Recent log
+    if [ -f "$BRIDGE_LOG" ]; then
+        echo ""
+        echo "Recent bridge log (last 5 lines):"
+        tail -5 "$BRIDGE_LOG" 2>/dev/null | sed 's/^/  /'
+    fi
+}
+
+# =============================================================================
+# Main Entry Point
+# =============================================================================
+
+main() {
+    # Parse command line options
+    case "${1:-}" in
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        --start-bridge)
+            check_prerequisites
+            start_bridge
+            exit $?
+            ;;
+        --stop-bridge)
+            stop_bridge
+            log_info "Bridge stopped"
+            exit 0
+            ;;
+        --status)
+            show_status
+            exit 0
+            ;;
+        --check)
+            check_prerequisites
+            log_info "All checks passed!"
+            exit 0
+            ;;
+        --debug)
+            export UPWORK_BRIDGE_DEBUG=1
+            shift
+            ;;
+    esac
+
+    # Normal operation: check, start bridge, launch Upwork
+    check_prerequisites
+    start_bridge
+    launch_upwork "$@"
+}
+
+main "$@"


### PR DESCRIPTION
Major changes:
- Replace grim with Flameshot as primary screenshot tool (grim doesn't work on GNOME)
- Add gnome-screenshot as fallback backend
- Implement proper backend abstraction with automatic fallback
- Add comprehensive error handling and logging
- Create setup.sh for easy installation and configuration
- Improve upwork-launcher.sh with status checks and CLI options
- Add systemd user service support
- Update README with architecture diagram and troubleshooting

Key features:
- Multiple screenshot backends with automatic fallback
- Proper Wayland environment handling
- Idle time monitoring via org.gnome.Mutter.IdleMonitor
- Desktop entry creation for app menu integration
- Debug mode for troubleshooting

This addresses the critical issue that grim uses wlr-screencopy protocol which GNOME/Mutter doesn't implement, making the previous solution non-functional on GNOME Wayland.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated setup for major Linux distros with install and service options
  * Launcher with bridge lifecycle commands (start/stop/status) and safer launch flow
  * Screenshot capture with multiple backends (Flameshot, GNOME Screenshot) and area/full captures
  * Idle monitoring exposed for integrations

* **Documentation**
  * Overhauled README with installation, quick start, usage, troubleshooting, architecture, and research references

* **Chores**
  * Added standard .gitignore for Python projects

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->